### PR TITLE
Fix HTTPS video download

### DIFF
--- a/reolinkapi/handlers/api_handler.py
+++ b/reolinkapi/handlers/api_handler.py
@@ -124,7 +124,7 @@ class APIHandler(AlarmAPIMixin,
                 tgt_filepath = data[0].pop('filepath')
                 # Apply the data to the params
                 params.update(data[0])
-                with requests.get(self.url, params=params, stream=True) as req:
+                with requests.get(self.url, params=params, stream=True, verify=False, timeout=(1, None)) as req:
                     if req.status_code == 200:
                         with open(tgt_filepath, 'wb') as f:
                             f.write(req.content)


### PR DESCRIPTION
Adding missing `verify=False` parameter to fix the error:
`(Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: EE certificate key too weak (_ssl.c:1124)')))`

Also, I would suggest using HTTPS by default, otherwise you are leaking the username and password to everyone on the network.