### PR TITLE
Move streaming dependencies to their own "extra"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Install the package via PyPi
 Install from GitHub
 
     pip install git+https://github.com/ReolinkCameraAPI/reolinkapipy.git
+
+If you want to include the video streaming functionality you need to include the streaming "extra" dependencies
+
+    pip install 'reolinkapi[streaming]'
     
 ## Contributors
 

--- a/reolinkapi/mixins/stream.py
+++ b/reolinkapi/mixins/stream.py
@@ -5,48 +5,59 @@ from urllib import parse
 from io import BytesIO
 
 import requests
-from PIL.Image import Image, open as open_image
 
-from reolinkapi.utils.rtsp_client import RtspClient
+try:
+    from PIL.Image import Image, open as open_image
+
+    from reolinkapi.utils.rtsp_client import RtspClient
 
 
-class StreamAPIMixin:
-    """ API calls for opening a video stream or capturing an image from the camera."""
+    class StreamAPIMixin:
+        """ API calls for opening a video stream or capturing an image from the camera."""
 
-    def open_video_stream(self, callback: Any = None, proxies: Any = None) -> Any:
-        """
-        'https://support.reolink.com/hc/en-us/articles/360007010473-How-to-Live-View-Reolink-Cameras-via-VLC-Media-Player'
-        Blocking function creates a generator and returns the frames as it is spawned
-        :param callback:
-        :param proxies: Default is none, example: {"host": "localhost", "port": 8000}
-        """
-        rtsp_client = RtspClient(
-            ip=self.ip, username=self.username, password=self.password, proxies=proxies, callback=callback)
-        return rtsp_client.open_stream()
+        def open_video_stream(self, callback: Any = None, proxies: Any = None) -> Any:
+            """
+            'https://support.reolink.com/hc/en-us/articles/360007010473-How-to-Live-View-Reolink-Cameras-via-VLC-Media-Player'
+            Blocking function creates a generator and returns the frames as it is spawned
+            :param callback:
+            :param proxies: Default is none, example: {"host": "localhost", "port": 8000}
+            """
+            rtsp_client = RtspClient(
+                ip=self.ip, username=self.username, password=self.password, proxies=proxies, callback=callback)
+            return rtsp_client.open_stream()
 
-    def get_snap(self, timeout: float = 3, proxies: Any = None) -> Optional[Image]:
-        """
-        Gets a "snap" of the current camera video data and returns a Pillow Image or None
-        :param timeout: Request timeout to camera in seconds
-        :param proxies: http/https proxies to pass to the request object.
-        :return: Image or None
-        """
-        data = {
-            'cmd': 'Snap',
-            'channel': 0,
-            'rs': ''.join(random.choices(string.ascii_uppercase + string.digits, k=10)),
-            'user': self.username,
-            'password': self.password,
-        }
-        parms = parse.urlencode(data).encode("utf-8")
+        def get_snap(self, timeout: float = 3, proxies: Any = None) -> Optional[Image]:
+            """
+            Gets a "snap" of the current camera video data and returns a Pillow Image or None
+            :param timeout: Request timeout to camera in seconds
+            :param proxies: http/https proxies to pass to the request object.
+            :return: Image or None
+            """
+            data = {
+                'cmd': 'Snap',
+                'channel': 0,
+                'rs': ''.join(random.choices(string.ascii_uppercase + string.digits, k=10)),
+                'user': self.username,
+                'password': self.password,
+            }
+            parms = parse.urlencode(data).encode("utf-8")
 
-        try:
-            response = requests.get(self.url, proxies=proxies, params=parms, timeout=timeout)
-            if response.status_code == 200:
-                return open_image(BytesIO(response.content))
-            print("Could not retrieve data from camera successfully. Status:", response.status_code)
-            return None
+            try:
+                response = requests.get(self.url, proxies=proxies, params=parms, timeout=timeout)
+                if response.status_code == 200:
+                    return open_image(BytesIO(response.content))
+                print("Could not retrieve data from camera successfully. Status:", response.status_code)
+                return None
 
-        except Exception as e:
-            print("Could not get Image data\n", e)
-            raise
+            except Exception as e:
+                print("Could not get Image data\n", e)
+                raise
+except ImportError:
+    class StreamAPIMixin:
+        """ API calls for opening a video stream or capturing an image from the camera."""
+
+        def open_video_stream(self, callback: Any = None, proxies: Any = None) -> Any:
+            raise ImportError('''open_video_stream requires streaming extra dependencies\nFor instance "pip install reolinkapi[streaming]"''')
+
+        def get_snap(self, timeout: float = 3, proxies: Any = None) -> Optional['Image']:
+            raise ImportError('''open_video_stream requires streaming extra dependencies\nFor instance "pip install reolinkapi[streaming]"''')

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,17 @@ AUTHOR_EMAIL = 'alanoterblanche@gmail.com'
 AUTHOR = 'Benehiko'
 LICENSE = 'GPL-3.0'
 INSTALL_REQUIRES = [
-    'numpy==1.19.4',
-    'opencv-python==4.4.0.46',
-    'Pillow==8.0.1',
     'PySocks==1.7.1',
     'PyYaml==5.3.1',
     'requests>=2.18.4',
 ]
+EXTRAS_REQUIRE = {
+    'streaming': [
+        'numpy==1.19.4',
+        'opencv-python==4.4.0.46',
+        'Pillow==8.0.1',
+    ],
+}
 
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -53,5 +57,6 @@ setup(
     url=URL,
     license=LICENSE,
     install_requires=INSTALL_REQUIRES,
-    packages=find_packages(exclude=['examples', 'tests'])
+    packages=find_packages(exclude=['examples', 'tests']),
+    extras_require=EXTRAS_REQUIRE
 )


### PR DESCRIPTION
This is a PR as a follow up to: https://github.com/ReolinkCameraAPI/reolinkapipy/issues/45

This will by default not include the numpy, Pillow, and opencv dependencies with the library install. Those will be installed with:
`pip install reolinkapi[streaming]`
 
 My test was to run the library locally with a virtualenv:
 
# Test without extra

Install:

```bash
pip install -e .
```

Run:

```python
Python 3.8.5 (default, Jan 27 2021, 15:41:15) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import reolinkapi
>>> cam = reolinkapi.Camera(HOST, USER, PASS)
Login success
>>> cam.open_video_stream()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/axlan/src/reolinkapipy/reolinkapi/mixins/stream.py", line 60, in open_video_stream
    raise ImportError('''open_video_stream requires streaming extra dependencies\nFor instance "pip install reolinkapi[streaming]"''')
ImportError: open_video_stream requires streaming extra dependencies
For instance "pip install reolinkapi[streaming]"
```
 
# Test with extra

Install:

```bash
pip install -e '.[streaming]'
```

Run:

```python
Python 3.8.5 (default, Jan 27 2021, 15:41:15) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import reolinkapi
>>> cam = reolinkapi.Camera(HOST, USER, PASS)
Login success
>>> cam.open_video_stream()
opening stream
```
 
 
 
 
 
 
 