### PR TITLE
Adding the ability of using the RTSP profile for the stream quality

### DIFF
--- a/reolinkapi/camera.py
+++ b/reolinkapi/camera.py
@@ -8,6 +8,7 @@ class Camera(APIHandler):
                  password: str = "",
                  https: bool = False,
                  defer_login: bool = False,
+                 profile: str = "main",
                  **kwargs):
         """
         Initialise the Camera object by passing the ip address.
@@ -23,6 +24,9 @@ class Camera(APIHandler):
         eg: {"http":"socks5://[username]:[password]@[host]:[port], "https": ...}
         More information on proxies in requests: https://stackoverflow.com/a/15661226/9313679
         """
+        if profile not in ["main", "sub"]:
+            raise Exception("Profile argument must be either \"main\" or \"sub\"")
+
         # For when you need to connect to a camera behind a proxy, pass
         # a proxy argument: proxy={"http": "socks5://127.0.0.1:8000"}
         APIHandler.__init__(self, ip, username, password, https=https, **kwargs)
@@ -33,6 +37,7 @@ class Camera(APIHandler):
         self.ip = ip
         self.username = username
         self.password = password
+        self.profile = profile
 
         if not defer_login:
             super().login()

--- a/reolinkapi/mixins/stream.py
+++ b/reolinkapi/mixins/stream.py
@@ -23,7 +23,7 @@ try:
             :param proxies: Default is none, example: {"host": "localhost", "port": 8000}
             """
             rtsp_client = RtspClient(
-                ip=self.ip, username=self.username, password=self.password, proxies=proxies, callback=callback)
+                ip=self.ip, username=self.username, password=self.password, profile=self.profile, proxies=proxies, callback=callback)
             return rtsp_client.open_stream()
 
         def get_snap(self, timeout: float = 3, proxies: Any = None) -> Optional[Image]:


### PR DESCRIPTION
Some devices can't decode megapixels per frame, adding the 640x480 stream to the options helps in these cases.