### PR TITLE
fix KeyError: value

### DIFF
--- a/reolinkapi/mixins/motion.py
+++ b/reolinkapi/mixins/motion.py
@@ -46,7 +46,12 @@ class MotionAPIMixin:
         body = [{"cmd": "Search", "action": 1, "param": search_params}]
 
         resp = self._execute_command('Search', body)[0]
-        result = resp['value']['SearchResult']
+        if 'value' not in resp:
+            return []
+        values = resp['value']
+        if 'SearchResult' not in values:
+            return []
+        result = values['SearchResult']
         files = result.get('File', [])
         if len(files) > 0:
             # Begin processing files


### PR DESCRIPTION
This fixes below error occurring when no motion video is available in the time frame provided to `get_motion_files`

```
File "/home/xux/.local/lib/python3.7/site-packages/reolinkapi/mixins/motion.py", line 49, in get_motion_files
  result = resp['value']['SearchResult']
KeyError: 'value'
```