### PR TITLE
add presets and calibration related methods, enance docs, add example jsons

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ GET:
 - [X] User -> Add User
 - [X] User -> Manage User
 - [X] Device -> HDD/SD Card
+- [x] PTZ -> Presets, Calibration Status
 - [ ] Zoom
 - [ ] Focus
 - [ ] Image (Brightness, Contrast, Saturation, Hue, Sharp, Mirror, Rotate)
@@ -134,7 +135,7 @@ SET:
 - [X] User -> Add User
 - [X] User -> Manage User
 - [X] Device -> HDD/SD Card (Format)
-- [x] PTZ
+- [x] PTZ (including calibrate)
 - [x] Zoom
 - [x] Focus
 - [X] Image (Brightness, Contrast, Saturation, Hue, Sharp, Mirror, Rotate)
@@ -153,3 +154,5 @@ do not work and is not supported here.
 - RLC-520
 - C1-Pro
 - D400
+- E1 Zoom
+

--- a/examples/response/GetPtzCheckState.json
+++ b/examples/response/GetPtzCheckState.json
@@ -1,0 +1,19 @@
+[
+  {
+    "cmd": "GetPtzCheckState",
+    "code": 0,
+    "initial": {
+      "PtzCheckState": 2
+    },
+    "range": {
+      "PtzCheckState": [
+        0,
+        1,
+        2
+      ]
+    },
+    "value": {
+      "PtzCheckState": 2
+    }
+  }
+]

--- a/examples/response/GetPtzPresets.json
+++ b/examples/response/GetPtzPresets.json
@@ -1,0 +1,926 @@
+[
+  {
+    "cmd": "GetPtzPreset",
+    "code": 0,
+    "initial": {
+      "PtzPreset": [
+        {
+          "channel": 0,
+          "enable": 1,
+          "id": 0,
+          "imgName": "preset_00",
+          "name": "namepos0"
+        },
+        {
+          "channel": 0,
+          "enable": 1,
+          "id": 1,
+          "imgName": "preset_01",
+          "name": "othernamepos1"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 2,
+          "imgName": "",
+          "name": "pos3"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 3,
+          "imgName": "",
+          "name": "pos4"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 4,
+          "imgName": "",
+          "name": "pos5"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 5,
+          "imgName": "",
+          "name": "pos6"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 6,
+          "imgName": "",
+          "name": "pos7"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 7,
+          "imgName": "",
+          "name": "pos8"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 8,
+          "imgName": "",
+          "name": "pos9"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 9,
+          "imgName": "",
+          "name": "pos10"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 10,
+          "imgName": "",
+          "name": "pos11"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 11,
+          "imgName": "",
+          "name": "pos12"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 12,
+          "imgName": "",
+          "name": "pos13"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 13,
+          "imgName": "",
+          "name": "pos14"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 14,
+          "imgName": "",
+          "name": "pos15"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 15,
+          "imgName": "",
+          "name": "pos16"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 16,
+          "imgName": "",
+          "name": "pos17"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 17,
+          "imgName": "",
+          "name": "pos18"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 18,
+          "imgName": "",
+          "name": "pos19"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 19,
+          "imgName": "",
+          "name": "pos20"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 20,
+          "imgName": "",
+          "name": "pos21"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 21,
+          "imgName": "",
+          "name": "pos22"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 22,
+          "imgName": "",
+          "name": "pos23"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 23,
+          "imgName": "",
+          "name": "pos24"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 24,
+          "imgName": "",
+          "name": "pos25"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 25,
+          "imgName": "",
+          "name": "pos26"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 26,
+          "imgName": "",
+          "name": "pos27"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 27,
+          "imgName": "",
+          "name": "pos28"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 28,
+          "imgName": "",
+          "name": "pos29"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 29,
+          "imgName": "",
+          "name": "pos30"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 30,
+          "imgName": "",
+          "name": "pos31"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 31,
+          "imgName": "",
+          "name": "pos32"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 32,
+          "imgName": "",
+          "name": "pos33"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 33,
+          "imgName": "",
+          "name": "pos34"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 34,
+          "imgName": "",
+          "name": "pos35"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 35,
+          "imgName": "",
+          "name": "pos36"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 36,
+          "imgName": "",
+          "name": "pos37"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 37,
+          "imgName": "",
+          "name": "pos38"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 38,
+          "imgName": "",
+          "name": "pos39"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 39,
+          "imgName": "",
+          "name": "pos40"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 40,
+          "imgName": "",
+          "name": "pos41"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 41,
+          "imgName": "",
+          "name": "pos42"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 42,
+          "imgName": "",
+          "name": "pos43"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 43,
+          "imgName": "",
+          "name": "pos44"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 44,
+          "imgName": "",
+          "name": "pos45"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 45,
+          "imgName": "",
+          "name": "pos46"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 46,
+          "imgName": "",
+          "name": "pos47"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 47,
+          "imgName": "",
+          "name": "pos48"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 48,
+          "imgName": "",
+          "name": "pos49"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 49,
+          "imgName": "",
+          "name": "pos50"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 50,
+          "imgName": "",
+          "name": "pos51"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 51,
+          "imgName": "",
+          "name": "pos52"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 52,
+          "imgName": "",
+          "name": "pos53"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 53,
+          "imgName": "",
+          "name": "pos54"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 54,
+          "imgName": "",
+          "name": "pos55"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 55,
+          "imgName": "",
+          "name": "pos56"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 56,
+          "imgName": "",
+          "name": "pos57"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 57,
+          "imgName": "",
+          "name": "pos58"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 58,
+          "imgName": "",
+          "name": "pos59"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 59,
+          "imgName": "",
+          "name": "pos60"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 60,
+          "imgName": "",
+          "name": "pos61"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 61,
+          "imgName": "",
+          "name": "pos62"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 62,
+          "imgName": "",
+          "name": "pos63"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 63,
+          "imgName": "",
+          "name": "pos64"
+        }
+      ]
+    },
+    "range": {
+      "PtzPreset": {
+        "channel": 0,
+        "enable": "boolean",
+        "id": {
+          "max": 64,
+          "min": 1
+        },
+        "imgName": {
+          "maxLen": 31
+        },
+        "name": {
+          "maxLen": 31
+        }
+      }
+    },
+    "value": {
+      "PtzPreset": [
+        {
+          "channel": 0,
+          "enable": 1,
+          "id": 0,
+          "imgName": "preset_00",
+          "name": "0"
+        },
+        {
+          "channel": 0,
+          "enable": 1,
+          "id": 1,
+          "imgName": "preset_01",
+          "name": "1"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 2,
+          "imgName": "",
+          "name": "pos3"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 3,
+          "imgName": "",
+          "name": "pos4"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 4,
+          "imgName": "",
+          "name": "pos5"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 5,
+          "imgName": "",
+          "name": "pos6"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 6,
+          "imgName": "",
+          "name": "pos7"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 7,
+          "imgName": "",
+          "name": "pos8"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 8,
+          "imgName": "",
+          "name": "pos9"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 9,
+          "imgName": "",
+          "name": "pos10"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 10,
+          "imgName": "",
+          "name": "pos11"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 11,
+          "imgName": "",
+          "name": "pos12"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 12,
+          "imgName": "",
+          "name": "pos13"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 13,
+          "imgName": "",
+          "name": "pos14"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 14,
+          "imgName": "",
+          "name": "pos15"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 15,
+          "imgName": "",
+          "name": "pos16"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 16,
+          "imgName": "",
+          "name": "pos17"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 17,
+          "imgName": "",
+          "name": "pos18"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 18,
+          "imgName": "",
+          "name": "pos19"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 19,
+          "imgName": "",
+          "name": "pos20"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 20,
+          "imgName": "",
+          "name": "pos21"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 21,
+          "imgName": "",
+          "name": "pos22"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 22,
+          "imgName": "",
+          "name": "pos23"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 23,
+          "imgName": "",
+          "name": "pos24"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 24,
+          "imgName": "",
+          "name": "pos25"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 25,
+          "imgName": "",
+          "name": "pos26"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 26,
+          "imgName": "",
+          "name": "pos27"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 27,
+          "imgName": "",
+          "name": "pos28"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 28,
+          "imgName": "",
+          "name": "pos29"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 29,
+          "imgName": "",
+          "name": "pos30"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 30,
+          "imgName": "",
+          "name": "pos31"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 31,
+          "imgName": "",
+          "name": "pos32"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 32,
+          "imgName": "",
+          "name": "pos33"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 33,
+          "imgName": "",
+          "name": "pos34"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 34,
+          "imgName": "",
+          "name": "pos35"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 35,
+          "imgName": "",
+          "name": "pos36"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 36,
+          "imgName": "",
+          "name": "pos37"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 37,
+          "imgName": "",
+          "name": "pos38"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 38,
+          "imgName": "",
+          "name": "pos39"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 39,
+          "imgName": "",
+          "name": "pos40"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 40,
+          "imgName": "",
+          "name": "pos41"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 41,
+          "imgName": "",
+          "name": "pos42"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 42,
+          "imgName": "",
+          "name": "pos43"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 43,
+          "imgName": "",
+          "name": "pos44"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 44,
+          "imgName": "",
+          "name": "pos45"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 45,
+          "imgName": "",
+          "name": "pos46"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 46,
+          "imgName": "",
+          "name": "pos47"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 47,
+          "imgName": "",
+          "name": "pos48"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 48,
+          "imgName": "",
+          "name": "pos49"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 49,
+          "imgName": "",
+          "name": "pos50"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 50,
+          "imgName": "",
+          "name": "pos51"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 51,
+          "imgName": "",
+          "name": "pos52"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 52,
+          "imgName": "",
+          "name": "pos53"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 53,
+          "imgName": "",
+          "name": "pos54"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 54,
+          "imgName": "",
+          "name": "pos55"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 55,
+          "imgName": "",
+          "name": "pos56"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 56,
+          "imgName": "",
+          "name": "pos57"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 57,
+          "imgName": "",
+          "name": "pos58"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 58,
+          "imgName": "",
+          "name": "pos59"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 59,
+          "imgName": "",
+          "name": "pos60"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 60,
+          "imgName": "",
+          "name": "pos61"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 61,
+          "imgName": "",
+          "name": "pos62"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 62,
+          "imgName": "",
+          "name": "pos63"
+        },
+        {
+          "channel": 0,
+          "enable": 0,
+          "id": 63,
+          "imgName": "",
+          "name": "pos64"
+        }
+      ]
+    }
+  }
+]

--- a/examples/response/PtzCheck.json
+++ b/examples/response/PtzCheck.json
@@ -1,0 +1,1 @@
+[{"cmd": "PtzCheck", "code": 0, "value": {"rspCode": 200}}]

--- a/reolinkapi/mixins/ptz.py
+++ b/reolinkapi/mixins/ptz.py
@@ -5,6 +5,39 @@ class PtzAPIMixin:
     """
     API for PTZ functions.
     """
+    def get_ptz_check_state(self) -> Dict:
+        """
+        Get PTZ Check State Information that indicates whether calibration is required (0) running (1) or done (2)
+        Value is contained in response[0]["value"]["PtzCheckState"].
+        See examples/response/GetPtzCheckState.json for example response data.
+        :return: response json
+        """
+        body = [{"cmd": "GetPtzCheckState", "action": 1, "param": { "channel": 0}}]
+        return self._execute_command('GetPtzCheckState', body)
+
+    def get_ptz_presets(self) -> Dict:
+        """
+        Get ptz presets
+        See examples/response/GetPtzPresets.json for example response data.
+        :return: response json
+        """
+
+        body = [{"cmd": "GetPtzPreset", "action": 1, "param": { "channel": 0}}]
+        return self._execute_command('GetPtzPreset', body)
+
+    def perform_calibration(self) -> Dict:
+        """
+        Do the calibration (like app -> ptz -> three dots -> calibration). Moves camera to all end positions.
+        If not calibrated, your viewpoint of presets might drift. So before setting new presets, or moving to preset,
+        check calibration status (get_ptz_check_state -> 2 = calibrated) and perform calibration if not yet calibrated.
+        As of 2024-01-23 (most recent firmware 3.1.0.1711_23010700 for E1 Zoom) does not do this on startup.
+        Method blocks while calibrating.
+        See examples/response/PtzCheck.json for example response data.
+        :return: response json
+        """
+        data = [{"cmd": "PtzCheck", "action": 0, "param": {"channel": 0}}]
+        return self._execute_command('PtzCheck', data)
+
     def _send_operation(self, operation: str, speed: float, index: float = None) -> Dict:
         # Refactored to reduce redundancy
         param = {"channel": 0, "op": operation, "speed": speed}


### PR DESCRIPTION
To utilize the PTZ function, especially the presets, it's necessary to 'calibrate' some or at least the E1 Zoom camera to achieve non drifting behaviour when gearing towards stored preset locations. This can be achieved using the newly provided calibration function "perform_calibration" in this commit. Before calibrating, one can check whether the calibration is necessary using the get_ptz_check_state (PtzCheckState 2 being already calibrated). Also add get_ptz_presets function to get information about the currently stored presets. Tested on Reolink E1 Zoom on most recent firmware.