### PR TITLE
fix: video review example

### DIFF
--- a/examples/video_review_gui.py
+++ b/examples/video_review_gui.py
@@ -17,6 +17,9 @@ from PyQt6.QtMultimediaWidgets import QVideoWidget
 from PyQt6.QtCore import Qt, QUrl, QTimer, QThread, pyqtSignal, QMutex
 from PyQt6.QtGui import QColor, QBrush, QFont
 
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 def path_name_from_camera_path(fname):
    # Mp4Record/2024-08-12/RecM13_DST20240812_214255_214348_1F1E828_4DDA4D.mp4
    return fname.replace('/', '_')

--- a/examples/video_review_gui.py
+++ b/examples/video_review_gui.py
@@ -49,7 +49,7 @@ def decode_hex_to_flags(hex_value):
 def parse_filename(file_name):
     #  Mp4Record_2024-08-12_RecM13_DST20240812_214255_214348_1F1E828_4DDA4D.mp4
     # https://github.com/sven337/ReolinkLinux/wiki/Figuring-out-the-file-names#file-name-structure
-    pattern = r'.*?Mp4Record_(\d{4}-\d{2}-\d{2})_RecM(\d)\d_DST(\d{8})_(\d{6})_(\d{6})_(\w{4,8})_(\w{4,8})\.mp4'
+    pattern = r'.*?Mp4Record_(\d{4}-\d{2}-\d{2})_Rec[MS](\d)\d_DST(\d{8})_(\d{6})_(\d{6})_(\w{4,8})_(\w{4,8})\.mp4'
     match = re.match(pattern, file_name)
 
     if match:


### PR DESCRIPTION
Minor fixes to the video review app.
In particular we search for the main stream, but if you were to use "sub" or "autotrack" then the filename pattern becomes RecS (S for sub) instead of RecM, so fix filename parsing to allow for that.
https://github.com/sven337/ReolinkLinux/wiki/Figuring-out-the-file-names#stream-type
Also kill SSL warnings since my camera requires HTTPS and uses a self-signed cert.