### PR TITLE
download: use the Playback command instead of Download

### DIFF
--- a/reolinkapi/handlers/api_handler.py
+++ b/reolinkapi/handlers/api_handler.py
@@ -121,7 +121,7 @@ class APIHandler(AlarmAPIMixin,
         try:
             if self.token is None:
                 raise ValueError("Login first")
-            if command == 'Download':
+            if command == 'Download' or command == 'Playback':
                 # Special handling for downloading an mp4
                 # Pop the filepath from data
                 tgt_filepath = data[0].pop('filepath')

--- a/reolinkapi/mixins/download.py
+++ b/reolinkapi/mixins/download.py
@@ -1,18 +1,21 @@
 class DownloadAPIMixin:
     """API calls for downloading video files."""
-    def get_file(self, filename: str, output_path: str) -> bool:
+    def get_file(self, filename: str, output_path: str, method = 'Playback') -> bool:
         """
         Download the selected video file
+        On at least Trackmix Wifi, it was observed that the Playback method
+        yields much improved download speeds over the Download method, for
+        unknown reasons.
         :return: response json
         """
         body = [
             {
-                "cmd": "Download",
+                "cmd": method,
                 "source": filename,
                 "output": filename,
                 "filepath": output_path
             }
         ]
-        resp = self._execute_command('Download', body)
+        resp = self._execute_command(method, body)
 
         return resp


### PR DESCRIPTION
On my TrackMix Wifi, both API commands work the same way, but Download is limited to about 800kB/s, while Playback hits about 4MB/s. So, replace the Download command with Playback for get_file.