### PR TITLE
Fix safe encoding for passwords with exclamation mark

### DIFF
--- a/reolinkapi/mixins/stream.py
+++ b/reolinkapi/mixins/stream.py
@@ -40,7 +40,7 @@ try:
                 'user': self.username,
                 'password': self.password,
             }
-            parms = parse.urlencode(data).encode("utf-8")
+            parms = parse.urlencode(data, safe="!").encode("utf-8")
 
             try:
                 response = requests.get(self.url, proxies=proxies, params=parms, timeout=timeout)


### PR DESCRIPTION
Passwords with `!` characters are wrongly encoded, so the Reolink API does not interpret them correctly. By using the `safe` keyword, `!` are not encoded and thus consumed correctly by the Reolink camera. Tested with a RLC-823A.