### PR TITLE
Add PtzPreset to SetPtzPreset POST data

### DIFF
--- a/reolinkapi/mixins/ptz.py
+++ b/reolinkapi/mixins/ptz.py
@@ -51,8 +51,8 @@ class PtzAPIMixin:
         return self._execute_command('PtzCtrl', data)
 
     def _send_set_preset(self, enable: float, preset: float = 1, name: str = 'pos1') -> Dict:
-        data = [{"cmd": "SetPtzPreset", "action": 0, "param": {
-            "channel": 0, "enable": enable, "id": preset, "name": name}}]
+        data = [{"cmd": "SetPtzPreset", "action": 0, "param": { "PtzPreset": {
+            "channel": 0, "enable": enable, "id": preset, "name": name}}}]
         return self._execute_command('PtzCtrl', data)
 
     def go_to_preset(self, speed: float = 60, index: float = 1) -> Dict:


### PR DESCRIPTION
Hi,
I was using `reolinkapi==0.4.1` with an E1 zoom camera and when calling `add_preset` from `ptz.py` I got the following error:
```
[{'cmd': 'SetPtzPreset', 'code': 1, 'error': {'detail': 'not exist', 'rspCode': -1}}]
```
Which means "Missing Parameters".

Adding `PtzPreset` to the POST data fixed it for me.

From Camera HTTP API version 5, 
![Screenshot 2025-06-05 at 00 20 35](https://github.com/user-attachments/assets/4785b538-cc90-401e-9afe-646403301129)

PS: Thank you for maintaining this repo, has been super fun to use. I am using an E1 zoom camera mounted on top of a mobile robot :) 